### PR TITLE
Fix error in get_template() with selecting last option

### DIFF
--- a/R/get_template.R
+++ b/R/get_template.R
@@ -26,7 +26,7 @@ get_template <- function(example_name = NULL, install_to = "") {
 
     answer <- as.integer(answer)
 
-    if (is.na(answer) || answer < 1 || answer >= length(examples)) {
+    if (is.na(answer) || answer < 1 || answer > length(examples)) {
       message("Template selection aborted")
       return(invisible())
     }


### PR DESCRIPTION
This pull request includes a minor bug fix in the template selection logic. The conditional check for a valid template index now correctly allows selection of the last template option.

* Fixed the index validation in `get_template` so that users can select the last template in the list.