### PR TITLE
Add doc link to get_template() call when called with no arguments

### DIFF
--- a/R/get_template.R
+++ b/R/get_template.R
@@ -39,12 +39,12 @@ get_template <- function(template_name = NULL, install_to = NULL) {
       full.names = FALSE,
       recursive = FALSE
     )
-    
+
     # Filter out excluded templates (hardcoded exclusion list)
     excluded_templates <- c("wastewater")
     examples <- examples[!examples %in% excluded_templates]
 
-    message("Choose from the following templates:")
+    message("Choose from the following templates (for details, see the package documentation: https://epiforesite.github.io/rbranding/):")
     for (i in seq_along(examples)) {
       message(i, ": ", examples[i])
     }


### PR DESCRIPTION
This pull request makes a minor improvement to the user messaging in the `get_template` function. The message now directs users to the package documentation for more information about available templates. 

* The `get_template` function in `R/get_template.R` now displays a message that includes a link to the package documentation, helping users find more details about templates.